### PR TITLE
Run Dockerfile command as nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ ADD .npmrc ./
 ADD package.json package-lock.json ./
 RUN npm install
 ADD . .
+RUN adduser -S app
+USER app
 CMD [ "sh" ]


### PR DESCRIPTION
Signed-off-by: Jeff Kennedy <jeffk@kiva.org>

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/master/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**
IoActive noted that Dockerfiles were executing commands and running apps as root users, which is a security issue.

**Changes proposed in this pull request**
Run Dockerfile command as nonroot user.

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**

