### PR TITLE
PRO-2329 do not set env from env.json if it already exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Common code for kiva protocol webservices",
   "license": "Apache-2.0",
   "homepage": "https://github.com/kiva/protocol-common#readme",

--- a/src/config.module.ts
+++ b/src/config.module.ts
@@ -33,6 +33,10 @@ export class ConfigModule {
         }
 
         for (const key of Object.keys(env)) {
+            // do not set env from env.json if it already exists
+            if (process.env[key] !== undefined)
+                continue;
+
             process.env[key] = env[key];
         }
 


### PR DESCRIPTION
Signed-off-by: Matt Raffel <mattr@kiva.org>

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/master/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**
PRO-2329

**Changes proposed in this pull request**
do not set env from env.json if it already exists

**🚀 Deployment changes 🚀**  
We will want to be careful that k8s secrets do not have values that are wrong but correct in the env.json files as the env.json values will no longer be applied when they exist in secrets (or as preexisting env)

**Other Notes**

