### PR TITLE
.npmrc: remove superfluous registry key

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-registry=https://registry.npmjs.org


### PR DESCRIPTION
Signed-off-by: Anthony Voutas <anthonyv@kiva.org>

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/master/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**
https://app.circleci.com/pipelines/github/kiva/protocol-common/124/workflows/60dd798e-6279-47b5-8364-2b29a61c7a17/jobs/128

```
npm ERR! publish Failed PUT 404
npm ERR! code E404
npm ERR! 404 Not found : protocol-common
npm ERR! 404 
npm ERR! 404  'protocol-common' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

**Changes proposed in this pull request**
Remove the superfluous registry key in the .npmrc in case that is causing issues

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**

