### PR TITLE
PRO-2868: Add a decorator to allow a class or method to not be auto-logged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.28",
+  "version": "0.1.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Common code for kiva protocol webservices",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/disable.auto.logging.decorator.ts
+++ b/src/disable.auto.logging.decorator.ts
@@ -1,3 +1,27 @@
 import { SetMetadata } from '@nestjs/common';
 
+/**
+ * This decorator provides a bypass for the auto-logging of HTTP routes that is provided by the LoggingInterceptor. You can set it on a controller
+ * or just on an individual route. If you have this decorator and the EnableAutoLogging decorator, with one on the controller and one on an individual
+ * route, the one on the individual route will be given preference. If you have both of them set in the same place, whichever one is defined last will
+ * be given preference.
+ *
+ * Example 1:
+ *
+ * @DisableAutoLogging()
+ * @Controller('person')
+ * export class PersonController {
+ *    @Get('/loggingDisabledRoute')
+ *    public async routeDefn() : Promise<any> { // route logic }
+ * }
+ *
+ * Example 2:
+ *
+ * @Controller('person')
+ * export class PersonController {
+ *    @DisableAutoLogging()
+ *    @Get('/loggingDisabledRoute')
+ *    public async routeDefn() : Promise<any> { // route logic }
+ * }
+ */
 export const DisableAutoLogging = () => SetMetadata('autoLoggingDisabled', true);

--- a/src/disable.auto.logging.decorator.ts
+++ b/src/disable.auto.logging.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const DisableAutoLogging = () => SetMetadata('autoLoggingDisabled', true);

--- a/src/enable.auto.logging.decorator.ts
+++ b/src/enable.auto.logging.decorator.ts
@@ -1,0 +1,22 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * This decorator is the pair to the DisableAutoLogging decorator. You don't normally need to use it, since logging of routes is enabled by default if
+ * you're using the LoggingInterceptor. The purpose of it is to provide an override of the DisableAutoLogging decorator. In other words, if you have
+ * set @DisableAutoLogging() on a controller, you can re-enable auto-logging on a specific route by setting @EnableAutoLogging().
+ *
+ * Example 1:
+ *
+ * @DisableAutoLogging()
+ * @Controller('person')
+ * export class PersonController {
+ *
+ *    @Get('/loggingDisabledRoute')
+ *    public async routeDefn1() : Promise<any> { // route logic }
+ *
+ *    @EnableAutoLogging()
+ *    @Get('/loggingEnabledRoute')
+ *    public async routeDefn2() : Promise<any> { // route logic }
+ * }
+ */
+export const EnableAutoLogging = () => SetMetadata('autoLoggingDisabled', false);


### PR DESCRIPTION
| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/master/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**

**Changes proposed in this pull request**
* Add a decorator to allow a class or method to not be auto-logged.
  * Also adds a companion decorator to override that decorator (i.e. re-enable auto-logging for a specific method or class).
* Increment library version due to a breaking change:
  * Anyone who uses the global logger has to use a module in order to import the logger, in order to get the Reflector automatically injection. (I'll follow up with PRs in the relevant services to make this change.)

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>