### PR TITLE
PRO-2949: Add @IsValidInstanceOf validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Common code for kiva protocol webservices",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/non.empty.array.ts
+++ b/src/non.empty.array.ts
@@ -1,0 +1,12 @@
+/**
+ * This is a type that represents an array that must have at least one value, enforced by a transpiler check. Because this is a transpile-time check,
+ * you may need to use the isNonEmptyArray typeguard for arrays that are populated at runtime.
+ */
+export type NonEmptyArray<T> = [T, ...T[]];
+
+/**
+ * Typeguard for NonEmptyArray<T>. Guarantees that a given array is not an empty array.
+ */
+export function isNonEmptyArray<T>(arr: T[]): arr is NonEmptyArray<T> {
+    return arr.length > 0;
+}

--- a/src/validation/common/builders/is.valid.instance.builder.ts
+++ b/src/validation/common/builders/is.valid.instance.builder.ts
@@ -1,17 +1,16 @@
-import { ClassConstructor, plainToClass } from 'class-transformer';
-import { validateSync } from 'class-validator';
-import { ParamValidationWithType } from '../param.validation.with.type';
-import { formatErrors } from '../utility/error.utility';
+import { ParamValidationWithTypeMetadata } from '../param.validation.with.type.metadata';
+import { isValidInstanceOfBuilder } from './is.valid.instance.of.builder';
+import { ClassConstructor } from 'class-transformer';
 
 /**
- * Returns a function that can be used to validate that the provided param is a valid instance of the provided paramType.
- * TODO: Add support for union types
+ * Returns a function that can be used to validate that the provided param is a valid instance of the provided paramType. If you need to validate
+ * that the provided param is a valid instance of one of several paramTypes, use isValidInstanceOfBuilder instead. In fact, this builder defers to
+ * the isValidInstanceOfBuilder and is provided for convenience.
  */
-export const isValidInstanceBuilder: () => ParamValidationWithType = () => <T extends object>(param: T, paramType: ClassConstructor<T>) => {
-    const paramAsClass = plainToClass<T, T>(paramType, param);
-    const errors = validateSync(paramAsClass);
+export const isValidInstanceBuilder: () => ParamValidationWithTypeMetadata = () => (param: any, paramType: ClassConstructor<any>) => {
+    const errors = isValidInstanceOfBuilder(paramType)(param);
     if (errors.length > 0) {
-        return formatErrors(errors);
+        return errors[0][paramType.name];
     }
     return [];
 };

--- a/src/validation/common/builders/is.valid.instance.of.builder.ts
+++ b/src/validation/common/builders/is.valid.instance.of.builder.ts
@@ -1,0 +1,43 @@
+import { ClassConstructor, plainToClass } from 'class-transformer';
+import { ParamValidation } from '../param.validation';
+import { ParamValidationError } from '../param.validation.error';
+import { validateSync } from 'class-validator';
+import { formatErrors } from '../utility/error.utility';
+import { NonEmptyArray } from '../../../non.empty.array';
+
+/**
+ * Returns a function that can be used to validate that the provided param is a valid instance of one of the provided paramType. If you know there
+ * will only be 1 paramType to validated against, it is recommended to use isValidInstanceBuilder, because there is no need to key validation errors
+ * on the name of the paramType.
+ */
+export const isValidInstanceOfBuilder: (...paramTypes: NonEmptyArray<ClassConstructor<any>>) => ParamValidation =
+    (...paramTypes: ClassConstructor<any>[]) => (param: any) => {
+
+    // Validate it is an object
+    if (param === null || param === undefined) {
+        return [new ParamValidationError('IsObject', `Value is null or undefined`, param)];
+    } else if (Array.isArray(param)) {
+        return [new ParamValidationError('IsObject', `Value must be an object but was an array.`, param)];
+    } else if (typeof param !== 'object') {
+        return [new ParamValidationError('IsObject', `Value must be an object but was ${typeof param}.`, param)];
+    }
+
+    // Check errors on all possible paramTypes
+    let success: boolean = false;
+    const allErrors: {[name: string]: any[]}[] = paramTypes.map((paramType: ClassConstructor<object>) => {
+        const name: string = paramType.name;
+        const paramAsClass = plainToClass(paramType, param);
+        const errors = validateSync(paramAsClass);
+        if (errors.length === 0) {
+            success = true;
+        }
+        return { [name]: formatErrors(errors) };
+    });
+
+    // Return results
+    if (success) {
+        return [];
+    } else {
+        return allErrors;
+    }
+};

--- a/src/validation/common/builders/is.valid.instance.of.builder.ts
+++ b/src/validation/common/builders/is.valid.instance.of.builder.ts
@@ -22,22 +22,15 @@ export const isValidInstanceOfBuilder: (...paramTypes: NonEmptyArray<ClassConstr
         return [new ParamValidationError('IsObject', `Value must be an object but was ${typeof param}.`, param)];
     }
 
-    // Check errors on all possible paramTypes
-    let success: boolean = false;
+    // Check errors on all possible paramTypes and return errors keyed on the class name.
     const allErrors: {[name: string]: any[]}[] = paramTypes.map((paramType: ClassConstructor<object>) => {
         const name: string = paramType.name;
         const paramAsClass = plainToClass(paramType, param);
         const errors = validateSync(paramAsClass);
-        if (errors.length === 0) {
-            success = true;
-        }
         return { [name]: formatErrors(errors) };
     });
 
-    // Return results
-    if (success) {
-        return [];
-    } else {
-        return allErrors;
-    }
+    // We want to return no errors if any object's validation passed; this is an OR operation, not an AND.
+    const someClassPassedValidation = allErrors.some((entry: {[name: string]: any[]}) => Object.values(entry).flat().length === 0);
+    return someClassPassedValidation ? [] : allErrors;
 };

--- a/src/validation/common/param.validation.with.type.metadata.ts
+++ b/src/validation/common/param.validation.with.type.metadata.ts
@@ -1,0 +1,3 @@
+import { ClassConstructor } from 'class-transformer';
+
+export type ParamValidationWithTypeMetadata = (param: any, ...paramTypes: ClassConstructor<any>[]) => any[];

--- a/src/validation/common/param.validation.with.type.ts
+++ b/src/validation/common/param.validation.with.type.ts
@@ -1,3 +1,0 @@
-import { ClassConstructor } from 'class-transformer';
-
-export type ParamValidationWithType = (param: any, paramType: ClassConstructor<any>) => any[];

--- a/src/validation/common/utility/common.utility.ts
+++ b/src/validation/common/utility/common.utility.ts
@@ -1,9 +1,9 @@
 import { ParamValidation } from '../param.validation';
-import { ParamValidationWithType } from '../param.validation.with.type';
+import { ParamValidationWithTypeMetadata } from '../param.validation.with.type.metadata';
 
 /**
  * Custom type guard to differentiate between ParamValidation and ParamValidationWithType.
  */
-export const isTypedValidation = (validation: ParamValidation | ParamValidationWithType): validation is ParamValidationWithType => {
-    return validation.length === 2;
+export const isTypedValidation = (validation: ParamValidation | ParamValidationWithTypeMetadata): validation is ParamValidationWithTypeMetadata => {
+    return validation.length > 1;
 };

--- a/src/validation/common/utility/decorator.utility.ts
+++ b/src/validation/common/utility/decorator.utility.ts
@@ -1,5 +1,5 @@
 import { ParamValidation } from '../param.validation';
-import { ParamValidationWithType } from '../param.validation.with.type';
+import { ParamValidationWithTypeMetadata } from '../param.validation.with.type.metadata';
 
 /**
  * Given a base name (probably the name of a function), generate a string that can be used to look up validations on that key.
@@ -12,10 +12,10 @@ export function paramValidationMetadataKey(baseKey: string): string {
  * Record a specified ParamValidation on the provided class prototype, method, and validations. In addition to any previously recorded validations,
  * this newly recorded validation will be run if that method is annotated with @ValidateParams.
  */
-export function buildParamValidationDecorator(validation: ParamValidation | ParamValidationWithType): ParameterDecorator {
+export function buildParamValidationDecorator(validation: ParamValidation | ParamValidationWithTypeMetadata): ParameterDecorator {
     return (targetPrototype: any, methodName: string, paramIndex: number) => {
         const key = paramValidationMetadataKey(methodName);
-        const validations: (ParamValidation | ParamValidationWithType)[] = Reflect.getMetadata(paramIndex, targetPrototype, key) || [];
+        const validations: (ParamValidation | ParamValidationWithTypeMetadata)[] = Reflect.getMetadata(paramIndex, targetPrototype, key) || [];
         validations.push(validation);
         Reflect.defineMetadata(paramIndex, validations, targetPrototype, key);
     };

--- a/src/validation/decorators/parameter/is.valid.instance.decorator.ts
+++ b/src/validation/decorators/parameter/is.valid.instance.decorator.ts
@@ -2,7 +2,11 @@ import { buildParamValidationDecorator } from '../../common/utility/decorator.ut
 import { isValidInstanceBuilder } from '../../common/builders/is.valid.instance.builder';
 
 /**
- * Parameter decorators. Register this validations as needing to be validated against its specified type when the method is called.
+ * Parameter decorator. Register this validations as needing to be validated against its specified type when the method is called. It will make sure
+ * the parameter is indeed an instance of the specified type. Additionally, it will validate any property validations applied via class-validator.
+ *
+ * Note: This parameter decorator can only be used on a parameter whose type is a single class. To validate a parameter whose type is a union of
+ * multiple classes, use @IsValidInstanceOf().
  *
  * Example:
  *

--- a/src/validation/decorators/parameter/is.valid.instance.of.decorator.ts
+++ b/src/validation/decorators/parameter/is.valid.instance.of.decorator.ts
@@ -1,0 +1,32 @@
+import { buildParamValidationDecorator } from '../../common/utility/decorator.utility';
+import { ClassConstructor } from 'class-transformer';
+import { isValidInstanceOfBuilder } from '../../common/builders/is.valid.instance.of.builder';
+import { NonEmptyArray } from '../../../non.empty.array';
+
+/**
+ * Parameter decorator. Register this validations as needing to be validated against one of several specified types when the method is called. It will
+ * make sure the parameter is indeed an instance of one of the specified type. Additionally, it will validate any property validations applied via
+ * class-validator.
+ *
+ * Note: If only one type is specified, it is recommended to use @IsValidInstance instead, because there is no need to key validation errors on the
+ * name of the paramType.
+ *
+ * Example:
+ *
+ * class MyDto1 {
+ *     @IsInt() id: number
+ * }
+ * class MyDto2 {
+ *     @Min(1) positiveNumber: number
+ * }
+ * class MyService {
+ *     @ValidateParams
+ *     public sampleFun(@IsValidInstanceOf(MyDto1, MyDto2) dto: MyDto1 | MyDto2) {
+ *         ...
+ *     }
+ * }
+ */
+export const IsValidInstanceOf: (...paramTypes: NonEmptyArray<ClassConstructor<any>>) => ParameterDecorator =
+    (...paramTypes: NonEmptyArray<ClassConstructor<any>>) => {
+        return buildParamValidationDecorator(isValidInstanceOfBuilder(...paramTypes));
+};

--- a/src/validation/validations/is.valid.instance.of.ts
+++ b/src/validation/validations/is.valid.instance.of.ts
@@ -1,0 +1,26 @@
+import { ClassConstructor } from 'class-transformer';
+import { throwValidationException } from '../common/utility/error.utility';
+import { NonEmptyArray } from '../../non.empty.array';
+import { isValidInstanceOfBuilder } from '../common/builders/is.valid.instance.of.builder';
+
+/**
+ * Verify that the provided parameter is a valid instance of the provided type. It will also check any class-validation property validations that are
+ * on the class. If validation fails, then it will return an array of all validation errors, each one of which is a map where the id is the name of
+ * the paramType whose validations failed. If only one type is specified, it is recommended to use isValidInstance() instead, because there is no need
+ * to key validation errors on the name of the paramType.
+ */
+export const isValidInstanceOf = (param: any, ...paramTypes: NonEmptyArray<ClassConstructor<any>>) => {
+    return isValidInstanceOfBuilder(...paramTypes)(param);
+};
+
+/**
+ * Verify that the provided parameter is a valid instance of the provided type. It will also check any class-validation property validations that are
+ * on the class. If validation fails, then it will throw an exception. If only one type is specified, it is recommended to use isValidInstance()
+ * instead, because there is no need to key validation errors on the name of the paramType.
+ */
+export const isValidInstanceOfOrFail = (param: any, ...paramTypes: NonEmptyArray<ClassConstructor<any>>) => {
+    const errors: any[] = isValidInstanceOf(param, ...paramTypes);
+    if (errors.length > 0) {
+        throwValidationException(errors);
+    }
+};

--- a/src/validation/validations/is.valid.instance.ts
+++ b/src/validation/validations/is.valid.instance.ts
@@ -4,17 +4,19 @@ import { throwValidationException } from '../common/utility/error.utility';
 
 /**
  * Verify that the provided parameter is a valid instance of the provided type. It will also check any class-validation property validations that are
- * on the class. If validation fails, then it will return an array of all validation errors.
+ * on the class. If validation fails, then it will return an array of all validation errors. To validate a parameter whose type is a union of
+ * multiple classes, use isValidInstanceOf().
  */
-export const isValidInstance = <T extends object>(param: T, paramType: ClassConstructor<T>) => {
+export const isValidInstance = (param: any, paramType: ClassConstructor<any>) => {
     return isValidInstanceBuilder()(param, paramType);
 };
 
 /**
  * Verify that the provided parameter is a valid instance of the provided type. It will also check any class-validation property validations that are
- * on the class. If validation fails, then it will throw an exception.
+ * on the class. If validation fails, then it will throw an exception. To validate a parameter whose type is a union of multiple classes, use
+ * isValidInstanceOfOrFail().
  */
-export const isValidInstanceOrFail = <T extends object>(param: T, paramType: ClassConstructor<T>) => {
+export const isValidInstanceOrFail = (param: any, paramType: ClassConstructor<any>) => {
     const errors: any[] = isValidInstance(param, paramType);
     if (errors.length > 0) {
         throwValidationException(errors);

--- a/test/validation/decorators/parameter/is.valid.instance.of.decorator.spec.ts
+++ b/test/validation/decorators/parameter/is.valid.instance.of.decorator.spec.ts
@@ -1,0 +1,120 @@
+import { IsDate, IsInt, Length, Min } from 'class-validator';
+import { ValidateParams } from '../../../../src/validation/decorators/function/validate.params.decorator';
+import { ProtocolErrorCode } from '../../../../dist/protocol.errorcode';
+import { IsValidInstanceOf } from '../../../../src/validation/decorators/parameter/is.valid.instance.of.decorator';
+
+class TestClass1 {
+    @IsInt() id: number;
+    @Length(1) name: string;
+}
+
+class TestClass2 {
+    @IsDate() date: Date;
+    @Min(10) n: number;
+}
+
+class TestFixture {
+
+    @ValidateParams
+    testFn1(@IsValidInstanceOf(TestClass1) obj: TestClass1) {
+        return true;
+    }
+
+    @ValidateParams
+    testFn2(@IsValidInstanceOf(TestClass1, TestClass2) obj: TestClass1 | TestClass2) {
+        return true;
+    }
+}
+
+describe('@IsValidInstanceOf decorators tests', () => {
+
+    const fixture = new TestFixture();
+
+    describe('@IsValidInstanceOf a single class', () => {
+
+        it('should succeed given valid fields of an `any` typed object', () => {
+            const obj: any = {
+                id: 1,
+                name: 'foobar'
+            };
+            const result = fixture.testFn1(obj);
+            expect(result).toBe(true);
+        });
+
+        it('should succeed given valid fields of a properly typed object', () => {
+            const obj = new TestClass1();
+            obj.id = 1;
+            obj.name = 'foobar';
+            const result = fixture.testFn1(obj);
+            expect(result).toBe(true);
+        });
+
+        it('should fail if provided an instance with one invalid field',  () => {
+            const obj: any = {
+                id: 'foobar',
+                name: 'foobar'
+            };
+            try {
+                fixture.testFn1(obj);
+                fail('Expected a ValidationException error to be thrown');
+            } catch (e) {
+                expect(e.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+                expect(e.details).toHaveLength(1);
+                const classErrors = e.details.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+                expect(classErrors).toHaveLength(1);
+            }
+        });
+
+        it('should fail if provided an instance with multiple invalid fields', () => {
+            const obj: any = {
+                id: 11.1,
+                name: ''
+            };
+            try {
+                fixture.testFn1(obj);
+                fail('Expected a ValidationException error to be thrown');
+            } catch (e) {
+                expect(e.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+                expect(e.details).toHaveLength(1);
+                const classErrors = e.details.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+                expect(classErrors).toHaveLength(2);
+            }
+        });
+    });
+
+    describe('@IsValidInstanceOf multiple possible classes', () => {
+
+        it('should succeed given valid fields of a properly typed object of any of multiple classes', () => {
+            const obj1 = new TestClass1();
+            obj1.id = 1;
+            obj1.name = 'foobar';
+            const obj2 = new TestClass2();
+            obj2.date = new Date(Date.now());
+            obj2.n = 11;
+
+            const result1 = fixture.testFn2(obj1);
+            expect(result1).toBe(true);
+            const result2 = fixture.testFn2(obj2);
+            expect(result2).toBe(true);
+        });
+
+        it('should fail if provided an instance that is not valid for any of multiple classes', () => {
+            const obj: any = {
+                id: 'foobar',
+                name: 'foobar'
+            };
+
+            try {
+                fixture.testFn2(obj);
+                fail('Expected a ValidationException error to be thrown');
+            } catch (e) {
+                expect(e.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+                expect(e.details).toHaveLength(2);
+                const class1Errors = e.details.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+                expect(class1Errors).toHaveLength(1);
+                const class2Errors = e.details.find((error) => Object.keys(error)[0] === TestClass2.name).TestClass2;
+                expect(class2Errors).toHaveLength(2);
+            }
+        });
+    });
+});

--- a/test/validation/validations/is.valid.instance.of.spec.ts
+++ b/test/validation/validations/is.valid.instance.of.spec.ts
@@ -1,0 +1,141 @@
+import { IsDate, IsInt, Length, Min } from 'class-validator';
+import { ProtocolErrorCode } from '../../../dist/protocol.errorcode';
+import { isValidInstanceOf, isValidInstanceOfOrFail } from '../../../src/validation/validations/is.valid.instance.of';
+
+class TestClass1 {
+    @IsInt() id: number;
+    @Length(1) name: string;
+}
+
+class TestClass2 {
+    @IsDate() date: Date;
+    @Min(10) n: number;
+}
+
+describe('isValidInstanceOf & isValidInstanceOfOrFail tests', () => {
+
+    describe('test validation against a single class', () => {
+
+        it('should succeed given valid fields of an `any` typed object', () => {
+            const obj: any = {
+                id: 1,
+                name: 'foobar'
+            };
+
+            // isValidInstanceOf
+            expect(isValidInstanceOf(obj, TestClass1)).toHaveLength(0);
+
+            // isValidInstanceOfOrFail
+            isValidInstanceOfOrFail(obj, TestClass1);
+        });
+
+        it('should succeed given valid fields of a properly typed object', () => {
+            const obj = new TestClass1();
+            obj.id = 1;
+            obj.name = 'foobar';
+
+            // isValidInstanceOf
+            expect(isValidInstanceOf(obj, TestClass1)).toHaveLength(0);
+
+            // isValidInstanceOfOrFail
+            isValidInstanceOfOrFail(obj, TestClass1);
+        });
+
+        it('should fail if provided an instance with one invalid field', () => {
+            const obj: any = {
+                id: 'foobar',
+                name: 'foobar'
+            };
+
+            // isValidInstanceOf
+            const errors = isValidInstanceOf(obj, TestClass1);
+            expect(errors).toHaveLength(1);
+            let classErrors = errors.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+            expect(classErrors).toHaveLength(1);
+
+            // isValidInstanceOfOrFail
+            try {
+                isValidInstanceOfOrFail(obj, TestClass1);
+                fail('Expected a ValidationException error to be thrown');
+            } catch (e) {
+                expect(e.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+                expect(e.details).toHaveLength(1);
+                classErrors = e.details.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+                expect(classErrors).toHaveLength(1);
+            }
+        });
+
+        it('should fail if provided an instance with multiple invalid fields', () => {
+            const obj: any = {
+                id: 11.1,
+                name: ''
+            };
+
+            // isValidInstanceOf
+            const errors = isValidInstanceOf(obj, TestClass1);
+            expect(errors).toHaveLength(1);
+            let classErrors = errors.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+            expect(classErrors).toHaveLength(2);
+
+            // isValidInstanceOfOrFail
+            try {
+                isValidInstanceOfOrFail(obj, TestClass1);
+                fail('Expected a ValidationException error to be thrown');
+            } catch (e) {
+                expect(e.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+                expect(e.details).toHaveLength(1);
+                classErrors = e.details.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+                expect(classErrors).toHaveLength(2);
+            }
+        });
+    });
+
+    describe('test validation against multiple classes', () => {
+
+        it('should succeed given valid fields of a properly typed object of any of multiple classes', () => {
+            const obj1 = new TestClass1();
+            obj1.id = 1;
+            obj1.name = 'foobar';
+            const obj2 = new TestClass2();
+            obj2.date = new Date(Date.now());
+            obj2.n = 11;
+
+
+            // isValidInstanceOf
+            expect(isValidInstanceOf(obj1, TestClass1, TestClass2)).toHaveLength(0);
+            expect(isValidInstanceOf(obj2, TestClass1, TestClass2)).toHaveLength(0);
+
+            // isValidInstanceOfOrFail
+            isValidInstanceOfOrFail(obj1, TestClass1, TestClass2);
+            expect(isValidInstanceOf(obj2, TestClass1, TestClass2)).toHaveLength(0);
+        });
+
+        it('should fail if provided an instance that is not valid for any of multiple classes', () => {
+            const obj: any = {
+                id: 'foobar',
+                name: 'foobar'
+            };
+
+            // isValidInstanceOf
+            const errors = isValidInstanceOf(obj, TestClass1, TestClass2);
+            expect(errors).toHaveLength(2);
+            let class1Errors = errors.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+            expect(class1Errors).toHaveLength(1);
+            let class2Errors = errors.find((error) => Object.keys(error)[0] === TestClass2.name).TestClass2;
+            expect(class2Errors).toHaveLength(2);
+
+            // isValidInstanceOfOrFail
+            try {
+                isValidInstanceOfOrFail(obj, TestClass1, TestClass2);
+                fail('Expected a ValidationException error to be thrown');
+            } catch (e) {
+                expect(e.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+                expect(e.details).toHaveLength(2);
+                class1Errors = e.details.find((error) => Object.keys(error)[0] === TestClass1.name).TestClass1;
+                expect(class1Errors).toHaveLength(1);
+                class2Errors = e.details.find((error) => Object.keys(error)[0] === TestClass2.name).TestClass2;
+                expect(class2Errors).toHaveLength(2);
+            }
+        });
+    });
+});

--- a/test/validation/validations/is.valid.instance.spec.ts
+++ b/test/validation/validations/is.valid.instance.spec.ts
@@ -9,7 +9,7 @@ class TestClass1 {
 
 describe('isValidInstance & isValidInstanceOrFail tests', () => {
 
-    it('should succeed given valid fields of an `any` tpyed object', () => {
+    it('should succeed given valid fields of an `any` typed object', () => {
         const obj: any = {
             id: 1,
             name: 'foobar'


### PR DESCRIPTION

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/master/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**

**Changes proposed in this pull request**
* Add @IsValidInstanceOf validation, which is a form of @IsValidInstance that works on multiple class constructors.
  * This decorator requires explicitly passing in the classes as it cannot infer them from the parameter type like @IsValidInstance can.
* Adds NonEmptyArray, which allows us to have a transpiler-time check on whether a provided array is empty. This is useful, for example, for hardcoded values.

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**


Signed-off-by: Jeff Kennedy <jeffk@kiva.org>