### PR TITLE
add random string generator to common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1850,6 +1850,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
       "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+    },
+    "crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "requires": {
+        "type-fest": "^1.0.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
+      }
     },
     "cssom": {
       "version": "0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1674,9 +1674,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Common code for kiva protocol webservices",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -41,6 +41,7 @@
     "class-validator": "^0.12.2",
     "cls-hooked": "^4.2.2",
     "crypto-js": "^4.0.0",
+    "crypto-random-string": "^4.0.0",
     "dd-trace": "^0.29.2",
     "dotenv": "^8.2.0",
     "express-opentracing": "^0.1.1",

--- a/src/random.string.generator.ts
+++ b/src/random.string.generator.ts
@@ -1,0 +1,37 @@
+import cryptoRandomString from 'crypto-random-string';
+
+export const LOWER_CASE_LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+export const UPPER_CASE_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+export const ALL_LETTERS = LOWER_CASE_LETTERS + UPPER_CASE_LETTERS;
+export const NUMBERS = '0123456789';
+export const ALPHANUMERIC = ALL_LETTERS + NUMBERS;
+export const URL_SAFE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~';
+export const ASCII = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+
+/**
+ * Generate a string of random characters. You can optionally specify the length of the generated string and the character set to select from.
+ *
+ * @param length Desired length of the generated string. Defaults to 10.
+ * @param charset Desired character set to select characters from at random. Default to Alphanumeric (a-zA-Z0-9).
+ */
+export const randomString = (length: number = 10, charset: string = ALPHANUMERIC) => {
+    return cryptoRandomString({ length, characters: charset });
+};
+
+/**
+ * Generate a random hexadecimal string. You can optionally specify the length of the generated string.
+ *
+ * @param length Desired length of the generated string. Defaults to 10.
+ */
+export const randomHexString = (length: number = 10) => {
+    return cryptoRandomString( { length, type: 'hex' });
+};
+
+/**
+ * Generate a random base64 string. You can optionally specify the length of the generated string.
+ *
+ * @param length Desired length of the generated string. Defaults to 10.
+ */
+export const randomBase64String = (length: number = 10) => {
+    return cryptoRandomString( { length, type: 'base64' });
+};


### PR DESCRIPTION
Signed-off-by: Jacob Saur <jsaur@kiva.org>

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/main/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**
Originally this random.string.generator class was just in aries-key-guardian, I want to use it in aries-controller too, so moving it to protocol-common
**Changes proposed in this pull request**

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**

