### PR TITLE
fix random-crypto-string version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1852,18 +1852,11 @@
       "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "crypto-random-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.1.tgz",
+      "integrity": "sha512-5j88ECEn6h17UePrLi6pn1JcLtAiANa3KExyr9y9Z5vo2mv56Gh3I4Aja/B9P9uyMwyxNHAHWv+nE72f30T5Dg==",
       "requires": {
-        "type-fest": "^1.0.1"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
+        "type-fest": "^0.8.1"
       }
     },
     "cssom": {
@@ -6115,8 +6108,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Common code for kiva protocol webservices",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -41,7 +41,7 @@
     "class-validator": "^0.12.2",
     "cls-hooked": "^4.2.2",
     "crypto-js": "^4.0.0",
-    "crypto-random-string": "^4.0.0",
+    "crypto-random-string": "^3.3.1",
     "dd-trace": "^0.29.2",
     "dotenv": "^8.2.0",
     "express-opentracing": "^0.1.1",


### PR DESCRIPTION
Signed-off-by: Jacob Saur <jsaur@kiva.org>

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/main/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**
I got too excited and upgrade to the latest version of crypto-random-string which only support ESM and not CommonJS - https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c . Since we're still using CommonJS in our repos we need to downgrade to the previous version.

**Changes proposed in this pull request**

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**

