### PR TITLE
run ci tests for node16 in preparation for upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,18 @@ version: 2.1
 orbs:
   node: circleci/node@4.1.0
 jobs:
+  build-and-test16:
+    executor:
+      name: node/default
+      tag: '16.14.2'
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run build
+      - run: npm run lint
+      - run: npm test
+      - run: node --version
+
   build-and-test:
     executor:
       name: node/default
@@ -20,4 +32,7 @@ jobs:
 workflows:
     build-and-test:
       jobs:
-        - build-and-test
+        - build-and-test16
+        - build-and-test:
+            requires:
+              - build-and-test16


### PR DESCRIPTION
Signed-off-by: Anthony Voutas <anthonyv@kiva.org>

| 🔥 | 🐞 | 🙋 | 🚫 | 🚀 |
|----|----|----|----|----|
|       |       |      |       |       |


*([Click here](https://github.com/kiva/protocol/blob/main/PULL_REQUEST_README.md) if you don't understand these emojis)*

**What issue is this targeting?**
Upgrading to node16 (https://github.com/kiva/protocol-architecture/issues/5)

**Changes proposed in this pull request**
Run common library tests in node16 to ensure that service upgrades are smooth with regards to this library

**🚀 Deployment changes 🚀**  
(_list added or removed env, db changes etc_)  

**Other Notes**
Another PR will be required once all the services are upgraded to node16 to actually deploy this library using node16. I just figured it's safer to keep deploying it as a node14 library until everything else is upgraded. Somebody can correct me if I'm wrong about that
