### PR TITLE
Fix middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protocol-common",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Common code for kiva protocol webservices",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -1,7 +1,7 @@
 import { initGlobalTracer } from 'opentracing';
 import jaeger from 'jaeger-client';
 import ddTrace from 'dd-trace';
-import middleware from 'express-opentracing';
+import expressOpenTracing from 'express-opentracing';
 import { Logger } from '@nestjs/common';
 
 /**
@@ -135,6 +135,6 @@ export const traceware = (serviceName: string) => {
           return next();
         }
         // trace calls
-        middleware({tracer})(req, res, next);
+        expressOpenTracing.default({tracer})(req, res, next);
       };
 };


### PR DESCRIPTION
Summary of Changes:
* ESModule version of express-opentracing requires a different usage due to the way they export functionality.
* Increment version to 1.1.1

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>