### PR TITLE
Update to 1.x.x Documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,10 @@ version: 2.1
 orbs:
   node: circleci/node@4.1.0
 jobs:
-  build-and-test16:
+  build-test-deploy:
     executor:
       name: node/default
       tag: '16.14.2'
-    steps:
-      - checkout
-      - run: npm install
-      - run: npm run build
-      - run: npm run lint
-      - run: npm test
-      - run: node --version
-
-  build-and-test:
-    executor:
-      name: node/default
-      tag: '14.15.1'
     steps:
       - checkout
       - run: npm install
@@ -29,10 +17,8 @@ jobs:
           if [ "$CIRCLE_BRANCH" == "main" ] && [ "$CD_SKIP" != "1" ]; then
               ./publish.sh
           fi
+
 workflows:
     build-and-test:
       jobs:
-        - build-and-test16
-        - build-and-test:
-            requires:
-              - build-and-test16
+        - build-test-deploy

--- a/README.md
+++ b/README.md
@@ -10,17 +10,11 @@ npm package for your work.
 
 If you'd like to use a local version of protocol-common instead of the version available through npm packages, we've
 added some handy scripts to help you do so.
-1. In protocol-common, run the command `npm run setup`
-    - This will compile your code into a dist/ directory and use the [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link)
-      utility to create a local symlink to that dist/ directory.
-2. In the project that will use protocol-common, run the command `npm link protocol-common`.
+1. In protocol-common, run the command `npm run build:pack`
+    - This will compile your code into a dist/ directory and create a `.tgz` installable binary of protocol-common.
+    - Note the path to the `.tgz`, this will be important for the next step!
+2. In the project that will use protocol-common, run the command `npm install <path to .tgz>`.
 3. Try it out!
-
-When you're finished, run the following commands in order to undo the local link:
-1. In the project that is using protocol-common, run the command `npm unlink protocol-common --no-save`
-    - Note that now you will not have any protocol-common dependency installed, so you may want to pull down the remote
-      version again by running `npm install`.
-2. In protocol-common, run the command `npm run teardown`
 
 # Contributing to protocol-common
 
@@ -69,3 +63,8 @@ To use the ConfigModule, data needs to be passed in.  The data needs to be a spe
      "prod": {}
    }
 ```
+
+# Migrating from 0.x.x to 1.x.x
+
+Looking to use the latest version of protocol-common, but currently using an older version? See
+[this doc](/docs/migrate.to.v1.md) for migration instructions.

--- a/docs/migrate.to.v1.md
+++ b/docs/migrate.to.v1.md
@@ -3,9 +3,9 @@
 There are several significant changes from 0.x.x to 1.x.x:
 * Breaking: Protocol-Common is now published as an ESModule library.
 * Breaking: Minimum node version supported is node 16.
-* Breaking: The underlying logging mechanism has been swapped out for Pino logger.
+* Breaking: The underlying logging mechanism (Winston) has been swapped out for Pino logger.
 * Breaking: Protocol-Common now provides shallow-imports and does not support deep imports.
-* Clients no longer need to keep a @nest/axios dependency in sync with Protocol-Common's version.
+* Breaking: New ProtocolHttpService implementation.
 
 ## Protocol-Common is now published as an ESModule library.
 
@@ -84,7 +84,7 @@ import { ProtocolValidationPipe } from 'protocol-common/validation/protocol.vali
 import { ProtocolValidationPipe } from 'protocol-common/validation'; // THIS IS GOOD!
 ```
 
-## Clients no longer need to keep a @nest/axios dependency in sync with Protocol-Common's version.
+## New ProtocolHttpService implementation.
 
 1. Delete any dependency on `@nestjs/axios` from your `package.json`
 2. Anywhere you were importing `HttpModule` from `@nestjs/axios` or `@nestjs/common`, now import `ProtocolHttpModule`

--- a/docs/migrate.to.v1.md
+++ b/docs/migrate.to.v1.md
@@ -1,0 +1,93 @@
+# Migrating from 0.x.x to 1.x.x
+
+There are several significant changes from 0.x.x to 1.x.x:
+* Breaking: Protocol-Common is now published as an ESModule library.
+* Breaking: Minimum node version supported is node 16.
+* Breaking: The underlying logging mechanism has been swapped out for Pino logger.
+* Breaking: Protocol-Common now provides shallow-imports and does not support deep imports.
+* Clients no longer need to keep a @nest/axios dependency in sync with Protocol-Common's version.
+
+## Protocol-Common is now published as an ESModule library.
+
+This has a few downstream effects for clients of Protocol-Common. Most importantly:
+1. Make sure your package.json specifies `"type": "module"`
+2. Make sure all imports of local components use the `.js` extension. This does not apply to components imported from
+   external sources (e.g. modules imported from npm).
+
+To make sure that this behavior is enforced in future updates to the codebase, we recommend adding the following rule
+to your `.eslint.json` configuration file:
+```
+"import/extensions": [
+    "error",
+    {
+        "js": "ignorePackages",
+        "json": "ignorePackages"
+    }
+]
+```
+
+## Minimum node version supported is node 16.
+
+In particular, this is true if you are importing any `.json` files in your application. If you are doing so, you need to
+add an assertion to your import line. This will likely cause a typescript error, so you'll also need to use a @ts-ignore
+flag. E.g.
+
+```
+// @ts-ignore: assertions are currently required when importing json
+import data from '../config/env.json' assert { type: 'json'};
+```
+
+See the documentation here for more information: [https://nodejs.org/docs/latest-v16.x/api/esm.html#json-modules](https://nodejs.org/docs/latest-v16.x/api/esm.html#json-modules)
+
+### Getting an eslint error now?
+
+Add this rule to your `.eslint.json` file:
+
+```
+"@typescript-eslint/ban-ts-comment": [
+    "error",
+    {
+        "ts-ignore": "allow-with-description"
+    }
+]
+```
+
+## The underlying logging mechanism has been swapped out for Pino logger.
+
+To use the new Logger you need to do 3 things:
+1. Add `ProtocolLoggerModule` to your module imports in `app.module.ts` (or wherever your top-level module is)
+2. At application start-up time, after loading your top-level module, use `ProtocolLogger` as your app logger:
+```
+app.useLogger(app.get(ProtocolLogger));
+```
+3. Anywhere you want to use the logger, import the default Nest Logger and use that:
+```
+import { Logger } from '@nestjs/common';
+```
+
+### Logger.info() -> Logger.log()
+
+Note that if you were using the previous Logger provided by this library, you might be using a `.info()` function.
+Unfortunately, that function does not exist on the default Nest Logger. Instead, use `.log()`
+
+## Protocol-Common now provides shallow-imports and does not support deep imports.
+
+When importing from protocol-common, import everything from the top level (except for validations, which has a different
+top-level import).
+
+E.g.
+```
+import { HttpConstants } from 'protocol-common/http-context/http.constants'; // DON'T DO THIS!
+import { HttpConstants } from 'protocol-common'; // THIS IS GOOD!
+
+import { ProtocolValidationPipe } from 'protocol-common/validation/protocol.validation.pipe'; // DON'T DO THIS!
+import { ProtocolValidationPipe } from 'protocol-common/validation'; // THIS IS GOOD!
+```
+
+## Clients no longer need to keep a @nest/axios dependency in sync with Protocol-Common's version.
+
+1. Delete any dependency on `@nestjs/axios` from your `package.json`
+2. Anywhere you were importing `HttpModule` from `@nestjs/axios` or `@nestjs/common`, now import `ProtocolHttpModule`
+   from protocol-common.
+3. Instead of manually creating a ProtocolHttpService, you can now just add it to the constructor and rely on NestJS's
+   dependency injection system.

--- a/docs/migrate.to.v1.md
+++ b/docs/migrate.to.v1.md
@@ -26,6 +26,35 @@ to your `.eslint.json` configuration file:
 ]
 ```
 
+### Jest + ESM
+
+Because our package is now exported as an ESModule, there may be some new and weird error messages you see if you use
+Jest for running unit tests in your own TypeScript application. Fear not! Here's how you can support ESM imports with
+TypeScript in Jest.
+
+1. If you have not already, install the `ts-jest` package as a dev dependency.
+```
+npm install --save-dev ts-jest
+```
+2. Add the following to your Jest configuration:
+```
+"globals": {
+    "ts-jest": {
+        "useESM": true
+    }
+},
+"extensionsToTreatAsEsm": [
+    ".ts"
+]
+```
+3. Be sure to add the `--experimental-vm-modules` flag to your Node environment prior to running Jest. You can read
+   [more about ESM support in Jest here](https://jestjs.io/docs/ecmascript-modules).
+```
+"scripts": {
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+}
+```
+
 ## Minimum node version supported is node 16.
 
 In particular, this is true if you are importing any `.json` files in your application. If you are doing so, you need to


### PR DESCRIPTION
Summary of Changes
* Add documentation on how to migrate to the newest version of protocol-common.
* Also, remove CI steps that execute against node versions < 16

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>